### PR TITLE
Refactor connection handling and harden upload utilities

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,10 @@ Imports:
     dplyr (>= 1.0.0),
     tidyr (>= 1.1.0),
     pool (>= 1.0.0)
+Suggests:
+    testthat (>= 3.0.0)
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
+Config/testthat/edition: 3

--- a/R/connections.R
+++ b/R/connections.R
@@ -1,144 +1,183 @@
+.phylosql_state <- new.env(parent = emptyenv())
 
-
-
-#' A phylosql Function
-#'
-#'
-#' @param path
-#' @param key
-#' @keywords
-#' @import dplyr
-#' @import RMariaDB
-#' @import DBI
-#' @export
-#'
-get_mtgn_connection<-
-  function(path=NULL,key=NULL){
-
-    if(exists('sql_creds')){
-      print('Fetching Con From Pool')
-      return(sql_creds$creds)
-
-    }else{
-
-      file<-
-        tryCatch({
-          read.csv( path, header=T)
-        },
-        error=
-          function(e){
-            return(NA)
-          })
-
-      if(class(file)=='data.frame'){
-
-        message("Fetching connection...")
-        con<-
-          DBI::dbConnect(
-            RMariaDB::MariaDB(),
-            host=file$host,
-            dbname=file$dbname,
-            port=file$port,
-            user=file$user,
-            password=key)
-        message("Complete ;)")
-        return(con)
-
-      }else{
-
-        stop("Oops! No secret key found.")
-
-      }
-
-    }
-
+load_connection_credentials <- function(path) {
+  if (is.null(path) || !nzchar(path)) {
+    stop("`path` must be a non-empty string to a credentials CSV file.", call. = FALSE)
   }
 
+  if (!file.exists(path)) {
+    stop(sprintf("Credential file does not exist: %s", path), call. = FALSE)
+  }
 
+  cols <- c(host = "character", dbname = "character", port = "integer", user = "character")
 
-#' A phylosql Function
+  creds <- tryCatch(
+    utils::read.csv(
+      path,
+      stringsAsFactors = FALSE,
+      nrows = 1,
+      colClasses = cols
+    ),
+    error = function(err) {
+      stop(sprintf("Unable to read credential file %s: %s", path, conditionMessage(err)), call. = FALSE)
+    }
+  )
+
+  missing_cols <- setdiff(names(cols), names(creds))
+  if (length(missing_cols) > 0) {
+    stop(
+      sprintf(
+        "Credential file %s is missing required column(s): %s",
+        path,
+        paste(missing_cols, collapse = ", ")
+      ),
+      call. = FALSE
+    )
+  }
+
+  creds[1, names(cols), drop = FALSE]
+}
+
+#' Establish and cache a connection to the MTGN database
 #'
+#' @param path Path to a CSV containing connection credentials with columns `host`, `dbname`, `port`, and `user`.
+#' @param key Secret corresponding to the credentials in `path` (e.g. password).
+#' @param refresh Whether to force reconnection even if a cached connection exists.
 #'
-#' @param path
-#' @param key
-#' @keywords
-#' @import dplyr
-#' @import RMariaDB
-#' @import pool
-#' @import DBI
+#' @return A live `DBIConnection` object.
 #' @export
+#' @importFrom DBI dbConnect dbDisconnect dbIsValid
+#' @importFrom RMariaDB MariaDB
+get_mtgn_connection <- function(path = NULL, key = NULL, refresh = FALSE) {
+  creds_cached <- .phylosql_state$credentials
+  key_cached <- .phylosql_state$key
+  con_cached <- .phylosql_state$connection
+
+  if (!isTRUE(refresh) && !is.null(con_cached) && DBI::dbIsValid(con_cached)) {
+    return(con_cached)
+  }
+
+  if (is.null(path)) {
+    if (is.null(creds_cached)) {
+      stop("No cached connection available; provide `path` and `key`.", call. = FALSE)
+    }
+    path <- creds_cached$path
+  }
+
+  if (is.null(key)) {
+    if (is.null(key_cached)) {
+      stop("No cached credentials available; provide `key`.", call. = FALSE)
+    }
+    key <- key_cached
+  }
+
+  if (!nzchar(key)) {
+    stop("`key` must be a non-empty password or access token.", call. = FALSE)
+  }
+
+  creds_df <- load_connection_credentials(path)
+
+  if (!is.null(con_cached) && DBI::dbIsValid(con_cached)) {
+    try(DBI::dbDisconnect(con_cached), silent = TRUE)
+  }
+
+  message("Establishing database connection...")
+  con <- DBI::dbConnect(
+    drv = RMariaDB::MariaDB(),
+    host = creds_df$host,
+    dbname = creds_df$dbname,
+    port = creds_df$port,
+    user = creds_df$user,
+    password = key
+  )
+  message("Connection established.")
+
+  .phylosql_state$connection <- con
+  .phylosql_state$credentials <- list(path = path, details = creds_df)
+  .phylosql_state$key <- key
+
+  con
+}
+
+#' Establish a pooled connection to the MTGN database
 #'
+#' @inheritParams get_mtgn_connection
+#' @param size Optional pool size configuration passed to [pool::dbPool()].
+#'
+#' @return A live `pool::Pool` object.
+#' @export
+#' @importFrom pool dbPool poolClose poolClosed
+set_pool <- function(path, key, size = NULL) {
+  creds_df <- load_connection_credentials(path)
 
-set_pool<- function(path,key){
+  if (!nzchar(key)) {
+    stop("`key` must be a non-empty password or access token.", call. = FALSE)
+  }
 
-  sql_creds <- new.env()
-  file = read.csv(path)
+  existing_pool <- .phylosql_state$pool
+  if (!is.null(existing_pool) && !pool::poolClosed(existing_pool)) {
+    pool::poolClose(existing_pool)
+  }
 
-  pool <- dbPool(
-    drv= RMariaDB::MariaDB(),
-    host = file$host,
-    dbname = file$dbname,
-    port = file$port,
-    user = file$user,
+  pool_args <- list(
+    drv = RMariaDB::MariaDB(),
+    host = creds_df$host,
+    dbname = creds_df$dbname,
+    port = creds_df$port,
+    user = creds_df$user,
     password = key
   )
 
-  sql_creds$creds <- pool
-  assign("sql_creds", sql_creds, .GlobalEnv)
-  #as.environment('package:phylosql')
-  # assign("sql_creds", sql_creds, 'package:phylosql')
+  if (!is.null(size)) {
+    pool_args <- c(pool_args, size)
+  }
 
+  pool <- do.call(pool::dbPool, pool_args)
 
+  .phylosql_state$pool <- pool
+  .phylosql_state$credentials <- list(path = path, details = creds_df)
+  .phylosql_state$key <- key
+
+  pool
 }
 
-
-#' A phylosql Function
+#' Attempt to reuse a cached connection or pool
 #'
-#'
-#' @param path
-#' @param key
-#' @keywords
-#' @import dplyr
-#' @import RMariaDB
-#' @import pool
-#' @import DBI
+#' @return A live database connection object or `NULL` if none are cached.
 #' @export
-#'
-
-try_fetch_connection<-
-
-  function(){
-
-  get_mtgn_connection()
-
+#' @importFrom DBI dbIsValid
+try_fetch_connection <- function() {
+  pool <- .phylosql_state$pool
+  if (!is.null(pool) && !pool::poolClosed(pool)) {
+    return(pool)
   }
 
-#' A phylosql Function
-#'
-#'
-#' @param path
-#' @param key
-#' @keywords
-#' @export
-#'
-
-try_fetch_connection_string<-
-
-  function(){
-
-    'get_mtgn_connection()'
-
+  con <- .phylosql_state$connection
+  if (!is.null(con) && DBI::dbIsValid(con)) {
+    return(con)
   }
 
-#' A phylosql Function
-#'
-#'
-#' @param path
-#' @param key
-#' @keywords
-#' @export
-#'
-eval_con<- function(x){
+  NULL
+}
 
-  eval(parse(text = paste0(x)))
+#' Return the expression used to lazily fetch a connection
+#'
+#' @return A character string representing a call to [get_mtgn_connection()].
+#' @export
+try_fetch_connection_string <- function() {
+  "get_mtgn_connection()"
+}
+
+#' Evaluate a connection expression in the caller environment
+#'
+#' @param expr Character string of R code that resolves to a connection when evaluated.
+#'
+#' @return The evaluated object (typically a connection).
+#' @export
+eval_con <- function(expr) {
+  if (missing(expr) || !is.character(expr) || length(expr) != 1L) {
+    stop("`expr` must be a single character string.", call. = FALSE)
+  }
+
+  eval(parse(text = expr), envir = parent.frame())
 }

--- a/R/upload.R
+++ b/R/upload.R
@@ -1,321 +1,333 @@
-
-#' A phylosql Function
-#'
-#' function to upload lab data to mysql database
-#' @param data data to upload
-#' @param database database to send data
-#' @param con connection
-#' @keywords
-#' @import dplyr
-#' @import RMariaDB
-#' @export
-#'
-
-
-upload_lab_data<-
-  function(data,database="labdata", con=NULL){
-    if(is.null(con)){
-      stop("You need to specify a database connection")
+resolve_connection <- function(con = NULL) {
+  if (!is.null(con)) {
+    if (!DBI::dbIsValid(con)) {
+      stop("`con` must be a valid DBI connection or pool object.", call. = FALSE)
     }
-
-    si<- dplyr::as_tibble(
-      dplyr::tbl(con,database))
-
-    existingID<- paste0(si$MetagenNumber,si$variable)
-    newID<- paste0(data$MetagenNumber,data$variable)
-
-    upload<- which(!newID %in% existingID)
-
-    stopifnot(length(upload)>0)
-    message(paste0("Uploading ",length(upload)," samples."))
-
-    RMariaDB::dbAppendTable(con, database,value= data[upload,] )
-    message("Complete.")
-
+    return(con)
   }
 
-
-#' A phylosql Function
-#'
-#' function to upload sv table to mysql database
-#' @param data data to upload
-#' @param database database to send data
-#' @param con connection
-#' @keywords
-#' @import dplyr
-#' @import RMariaDB
-#' @export
-#'
-
-upload_sv<-
-  function(data,database=NULL,con=NULL){
-
-    if(is.null(con)){
-      stop("You need to specify a database connection")
-    }
-
-    # Preprocess data for sql here
-
-    sv<- dplyr::as_tibble(
-      dplyr::tbl(con,database))
-
-    existingID<- paste0(sv$MetagenNumber,sv$SV)
-    newID<- paste0(data$MetagenNumber,data$SV)
-
-    upload<- which(!newID %in% existingID)
-    stopifnot(length(upload)>0)
-    message(paste0("Uploading ",length(upload)," samples."))
-    RMariaDB::dbAppendTable(con, database,value= data[upload,] )
-    message("Complete.")
+  cached <- try_fetch_connection()
+  if (is.null(cached)) {
+    stop("No cached database connection available. Provide `con` or establish one with `get_mtgn_connection()`.", call. = FALSE)
   }
 
-#' A phylosql Function
-#'
-#' function to upload taxonomy table to mysql database
-#' @param data data to upload
-#' @param database database to send data
-#' @param con connection
-#' @keywords
-#' @import dplyr
-#' @import RMariaDB
-#' @export
-#'
-
-upload_taxonomy<-
-  function(data,database=NULL,con=NULL){
-    if(is.null(con)){
-      stop("You need to specify a database connection")
-    }
-
-    data<- gsub("\\r","",data)
-
-    # Preprocess data for sql here
-
-    tax<- dplyr::as_tibble(
-      dplyr::tbl(con,database))
-
-    existingID<- paste0(tax$SV)
-    newID<- paste0(data$SV)
-
-    upload<- which(!newID %in% existingID)
-    stopifnot(length(upload)>0)
-    message(paste0("Uploading ",length(upload)," samples."))
-    RMariaDB::dbAppendTable(con, database,value= data[upload,] )
-    message("Complete.")
+  if (!DBI::dbIsValid(cached)) {
+    stop("Cached database connection is no longer valid. Reconnect with `get_mtgn_connection()`.", call. = FALSE)
   }
 
-#' A phylosql Function
-#'
-#' function to upload cms data to mysql database
-#' @param data data to upload
-#' @param database database to send data
-#' @param con connection
-#' @keywords
-#' @import dplyr
-#' @import RMariaDB
-#' @export
-#'
+  cached
+}
 
-upload_cms_data<-
-  function(data,database="cmsdata",con=NULL){
-
-    if(is.null(con)){
-      stop("You need to specify a database connection")
-    }
-
-
-    si<- dplyr::as_tibble(
-      dplyr::tbl(con,database))
-
-    existingID<- paste0(si$MetagenNumber)
-    newID<- paste0(data$MetagenNumber)
-
-    upload<- which(!newID %in% existingID)
-    stopifnot(length(upload)>0)
-    message(paste0("Uploading ",length(upload)," samples."))
-    RMariaDB::dbAppendTable(con, database,value= data[upload,] )
-    message("Complete.")
+validate_upload_data <- function(data, required_cols, context) {
+  if (is.null(data)) {
+    stop(sprintf("`data` must not be NULL for %s uploads.", context), call. = FALSE)
   }
 
-
-#' A phylosql Function
-#'
-#' function to upload cms data to mysql database
-#' @param data data to upload
-#' @param database database to send data
-#' @param con connection
-#' @keywords
-#' @import dplyr
-#' @import RMariaDB
-#' @export
-#'
-
-upload_cms_data_Long<-
-  function(data,database="cmsdatalong",con=NULL){
-
-    if(is.null(con)){
-
-      con <-  try_fetch_connection()
-
-    }
-
-    if(any(class(con)=='logical')){
-
-      stop('No connection to database.')
-
-    }
-    if(ncol(data)!=3){
-      stop("This data is not the correct format")
-    }
-    if(any(is.na(data$Level))){
-      stop("Some cells contain NAs. Delete these and reattempt upload.")
-    }
-
-    si<- dplyr::as_tibble(
-      dplyr::tbl(con,database))
-
-
-    existingID<- paste0(si$MetagenNumber,si$Factor)
-    newID<- paste0(data$MetagenNumber,data$Factor)
-    upload<- which(!newID %in% existingID)
-    stopifnot(length(upload)>0)
-    message(paste0("Uploading ",length(upload)," samples."))
-    RMariaDB::dbAppendTable(con, database,value= data[upload,] )
-    message("Complete.")
+  if (!is.data.frame(data)) {
+    data <- as.data.frame(data, stringsAsFactors = FALSE)
   }
 
-
-
-#' A phylosql Function
-#'
-#' function to upload a long format SV table to mysql database (quickly)
-#' @param data data to upload
-#' @param database database to send data
-#' @param con connection
-#' @keywords
-#' @import dplyr
-#' @import RMariaDB
-#' @export
-#'
-
-upload_bulk_sv<-
-  function (data, database = NULL, con = NULL)
-  {
-    if(is.null(con)){
-
-      con <-  try_fetch_connection()
-
-    }
-
-    if(any(class(con)=='logical')){
-
-      stop('No connection to database.')
-
-    }
-    if (is.null(database)) {
-      stop("You need to specify a database")
-    }
-    sv <- dplyr::as_tibble(dplyr::tbl(con, database))
-    existingID <- paste0(sv$MetagenNumber, sv$SV)
-    newID <- paste0(data$MetagenNumber, data$SV)
-    upload <- which(!newID %in% existingID)
-    if(length(upload) > 0){
-      message(paste0("Uploading ", length(upload), " samples."))
-    uploadData(data=data[upload,],database,con=con)
-    message("Complete.")
-   # dbDisconnect(con)
-    }
-
+  missing_cols <- setdiff(required_cols, names(data))
+  if (length(missing_cols) > 0) {
+    stop(
+      sprintf(
+        "Missing required column(s) for %s upload: %s",
+        context,
+        paste(missing_cols, collapse = ", ")
+      ),
+      call. = FALSE
+    )
   }
 
-#' A phylosql Function
-#'
-#' function to upload a taxonomy table to mysql database (quickly)
-#' @param data data to upload
-#' @param database database to send data
-#' @param con connection
-#' @keywords
-#' @import dplyr
-#' @import RMariaDB
-#' @export
-#'
+  data
+}
 
-upload_bulk_tax<-
-  function (data, database = NULL, con = NULL)
-  {
-    if(is.null(con)){
-
-      con <-  try_fetch_connection()
-
-    }
-
-    if(any(class(con)=='logical')){
-
-      stop('No connection to database.')
-
-    }
-    if (is.null(database)) {
-      stop("You need to specify a database")
-    }
-    tax <- dplyr::as_tibble(dplyr::tbl(con, database))
-    existingID <- paste0(tax$SV)
-    newID <- paste0(data$SV)
-    upload <- which(!newID %in% existingID)
-    if(length(upload) > 0){
-    message(paste0("Uploading ", length(upload), " samples."))
-    data<- gsub("\\\r","",as.matrix(data))
-
-    uploadData(data=data[upload,],database,con=con)
-    message("Complete.")
-   # dbDisconnect(con)
-    }
-
+combine_key <- function(df, columns) {
+  if (length(columns) == 1L) {
+    return(as.character(df[[columns]]))
   }
 
+  rows <- df[, columns, drop = FALSE]
+  apply(rows, 1, function(row) {
+    values <- ifelse(is.na(row), "<NA>", as.character(row))
+    paste(values, collapse = "\r")
+  })
+}
 
+collect_existing_keys <- function(con, table, key_cols) {
+  tbl <- dplyr::tbl(con, table)
+  selected <- dplyr::select(tbl, dplyr::all_of(key_cols))
+  dplyr::collect(selected)
+}
 
-#' A phylosql Function
-#'
-#'  A backend function for bulk uploading data to a mysql database
-#' @param data data to upload
-#' @param tableName database to send data
-#' @param con connection
-#' @keywords
-#' @import dplyr
-#' @import RMariaDB
-#' @export
-#'
-uploadData <-
-  function(data, # a data frame
-           tableName, # table name, possibly qualified (e.g. "my_db.customers")
-           con=NULL) # arguments to DBI::dbConnect
-  {
-    if(is.null(con)){
-
-      con <-  try_fetch_connection()
-
-    }
-
-    if(any(class(con)=='logical')){
-
-      stop('No connection to database.')
-
-    }
-   # TEMPFILE  <-  write.csv(fileext='.csv')
-   # TEMPFILE<- normalizePath(TEMPFILE, winslash = "/")
-    TEMPFILE = 'bulk_upload1.csv'
-    query  <-  sprintf("LOAD DATA LOCAL INFILE '%s'
-INTO TABLE %s
-FIELDS TERMINATED BY ','
-LINES TERMINATED BY '\\n'
-IGNORE 1 LINES;" , TEMPFILE,tableName)
-
-    write.csv(data,TEMPFILE, row.names = FALSE,quote = FALSE)
-    #
-    # CONNECT TO THE DATABASE
-    # SUBMIT THE UPDATE QUERY AND DISCONNECT
-    RMariaDB::dbExecute(con, query)
-    #dbDisconnect(con)
-    on.exit(file.remove(TEMPFILE))
+compute_new_indices <- function(existing, candidate, key_cols) {
+  if (!nrow(candidate)) {
+    return(integer())
   }
 
+  existing_keys <- if (nrow(existing)) combine_key(existing, key_cols) else character()
+  candidate_keys <- combine_key(candidate, key_cols)
+
+  which(!candidate_keys %in% existing_keys)
+}
+
+perform_append_upload <- function(con, table, data, key_cols, context, required_cols = key_cols, preprocess = identity) {
+  con <- resolve_connection(con)
+  data <- validate_upload_data(data, required_cols, context)
+  data <- preprocess(data)
+
+  if (!nrow(data)) {
+    message("Input data has 0 rows; nothing to upload.")
+    return(invisible(data))
+  }
+
+  existing <- collect_existing_keys(con, table, unique(key_cols))
+  indices <- compute_new_indices(existing, data, unique(key_cols))
+
+  if (!length(indices)) {
+    message("No new records to upload.")
+    return(invisible(data[0, , drop = FALSE]))
+  }
+
+  rows_to_upload <- data[indices, , drop = FALSE]
+  message(sprintf("Uploading %d record(s) to %s...", nrow(rows_to_upload), table))
+  DBI::dbAppendTable(con, table, value = rows_to_upload)
+  message("Upload complete.")
+
+  invisible(rows_to_upload)
+}
+
+remove_carriage_returns <- function(df) {
+  for (col in names(df)) {
+    if (is.character(df[[col]])) {
+      df[[col]] <- gsub("\r", "", df[[col]])
+    }
+  }
+  df
+}
+
+#' Upload laboratory data to a MySQL database
+#'
+#' @param data A data frame containing laboratory records.
+#' @param database The name of the target table. Defaults to `"labdata"`.
+#' @param con An existing database connection. If `NULL`, a cached connection will be used.
+#'
+#' @return Invisibly returns the rows uploaded.
+#' @export
+#' @importFrom DBI dbAppendTable dbIsValid
+upload_lab_data <- function(data, database = "labdata", con = NULL) {
+  perform_append_upload(
+    con = con,
+    table = database,
+    data = data,
+    key_cols = c("MetagenNumber", "variable"),
+    context = "lab data"
+  )
+}
+
+#' Upload sequence variant data to a MySQL database
+#'
+#' @inheritParams upload_lab_data
+#'
+#' @return Invisibly returns the rows uploaded.
+#' @export
+upload_sv <- function(data, database = NULL, con = NULL) {
+  if (is.null(database) || !nzchar(database)) {
+    stop("`database` must be provided when uploading sequence variant data.", call. = FALSE)
+  }
+
+  perform_append_upload(
+    con = con,
+    table = database,
+    data = data,
+    key_cols = c("MetagenNumber", "SV"),
+    context = "sequence variant data"
+  )
+}
+
+#' Upload taxonomy data to a MySQL database
+#'
+#' @inheritParams upload_lab_data
+#'
+#' @return Invisibly returns the rows uploaded.
+#' @export
+upload_taxonomy <- function(data, database = NULL, con = NULL) {
+  if (is.null(database) || !nzchar(database)) {
+    stop("`database` must be provided when uploading taxonomy data.", call. = FALSE)
+  }
+
+  perform_append_upload(
+    con = con,
+    table = database,
+    data = data,
+    key_cols = "SV",
+    context = "taxonomy data",
+    preprocess = remove_carriage_returns
+  )
+}
+
+#' Upload CMS data to a MySQL database
+#'
+#' @inheritParams upload_lab_data
+#'
+#' @return Invisibly returns the rows uploaded.
+#' @export
+upload_cms_data <- function(data, database = "cmsdata", con = NULL) {
+  perform_append_upload(
+    con = con,
+    table = database,
+    data = data,
+    key_cols = "MetagenNumber",
+    context = "CMS data"
+  )
+}
+
+#' Upload CMS long-format data to a MySQL database
+#'
+#' @inheritParams upload_lab_data
+#'
+#' @return Invisibly returns the rows uploaded.
+#' @export
+upload_cms_data_Long <- function(data, database = "cmsdatalong", con = NULL) {
+  con <- resolve_connection(con)
+  data <- validate_upload_data(data, c("MetagenNumber", "Factor", "Level"), "CMS long data")
+
+  if (!nrow(data)) {
+    message("Input data has 0 rows; nothing to upload.")
+    return(invisible(data))
+  }
+
+  if (any(is.na(data$Level))) {
+    stop("`Level` column contains missing values. Remove them before uploading.", call. = FALSE)
+  }
+
+  existing <- collect_existing_keys(con, database, c("MetagenNumber", "Factor"))
+  indices <- compute_new_indices(existing, data, c("MetagenNumber", "Factor"))
+
+  if (!length(indices)) {
+    message("No new records to upload.")
+    return(invisible(data[0, , drop = FALSE]))
+  }
+
+  rows_to_upload <- data[indices, , drop = FALSE]
+  message(sprintf("Uploading %d record(s) to %s...", nrow(rows_to_upload), database))
+  DBI::dbAppendTable(con, database, value = rows_to_upload)
+  message("Upload complete.")
+
+  invisible(rows_to_upload)
+}
+
+perform_bulk_upload <- function(data, database, con, key_cols, context, preprocess = identity) {
+  con <- resolve_connection(con)
+  data <- validate_upload_data(data, unique(c(key_cols)), context)
+  data <- preprocess(data)
+
+  if (!nrow(data)) {
+    message("Input data has 0 rows; nothing to upload.")
+    return(invisible(data))
+  }
+
+  existing <- collect_existing_keys(con, database, key_cols)
+  indices <- compute_new_indices(existing, data, key_cols)
+
+  if (!length(indices)) {
+    message("No new records to upload.")
+    return(invisible(data[0, , drop = FALSE]))
+  }
+
+  rows_to_upload <- data[indices, , drop = FALSE]
+  message(sprintf("Uploading %d record(s) to %s via bulk loader...", nrow(rows_to_upload), database))
+  uploadData(rows_to_upload, database, con = con)
+  message("Upload complete.")
+
+  invisible(rows_to_upload)
+}
+
+#' Bulk upload sequence variant data using `LOAD DATA`
+#'
+#' @inheritParams upload_lab_data
+#'
+#' @return Invisibly returns the rows uploaded.
+#' @export
+upload_bulk_sv <- function(data, database = NULL, con = NULL) {
+  if (is.null(database) || !nzchar(database)) {
+    stop("`database` must be provided when bulk uploading sequence variant data.", call. = FALSE)
+  }
+
+  perform_bulk_upload(
+    data = data,
+    database = database,
+    con = con,
+    key_cols = c("MetagenNumber", "SV"),
+    context = "sequence variant bulk upload"
+  )
+}
+
+#' Bulk upload taxonomy data using `LOAD DATA`
+#'
+#' @inheritParams upload_lab_data
+#'
+#' @return Invisibly returns the rows uploaded.
+#' @export
+upload_bulk_tax <- function(data, database = NULL, con = NULL) {
+  if (is.null(database) || !nzchar(database)) {
+    stop("`database` must be provided when bulk uploading taxonomy data.", call. = FALSE)
+  }
+
+  perform_bulk_upload(
+    data = data,
+    database = database,
+    con = con,
+    key_cols = "SV",
+    context = "taxonomy bulk upload",
+    preprocess = remove_carriage_returns
+  )
+}
+
+#' Bulk upload arbitrary data using `LOAD DATA`
+#'
+#' @param data A data frame of rows to upload.
+#' @param tableName The fully qualified table name.
+#' @param con An existing database connection. If `NULL`, a cached connection will be used.
+#' @param use_transaction Whether to wrap the bulk upload in a transaction.
+#'
+#' @return Invisibly returns the uploaded rows.
+#' @export
+#' @importFrom DBI dbExecute dbQuoteIdentifier dbQuoteString dbWithTransaction
+#' @importFrom utils write.csv
+uploadData <- function(data, tableName, con = NULL, use_transaction = FALSE) {
+  con <- resolve_connection(con)
+
+  if (!is.data.frame(data)) {
+    data <- as.data.frame(data, stringsAsFactors = FALSE)
+  }
+
+  if (!nrow(data)) {
+    message("Input data has 0 rows; nothing to upload.")
+    return(invisible(data))
+  }
+
+  temp_file <- tempfile(pattern = "phylosql-upload-", fileext = ".csv")
+  on.exit(unlink(temp_file), add = TRUE)
+
+  utils::write.csv(data, temp_file, row.names = FALSE, quote = TRUE, na = "")
+
+  query <- paste(
+    "LOAD DATA LOCAL INFILE",
+    DBI::dbQuoteString(con, normalizePath(temp_file, winslash = "/")),
+    "INTO TABLE",
+    DBI::dbQuoteIdentifier(con, tableName),
+    "FIELDS TERMINATED BY ','",
+    "ENCLOSED BY '""'",
+    "LINES TERMINATED BY '\\n'",
+    "IGNORE 1 LINES"
+  )
+
+  if (isTRUE(use_transaction)) {
+    DBI::dbWithTransaction(con, DBI::dbExecute(con, query))
+  } else {
+    DBI::dbExecute(con, query)
+  }
+
+  invisible(data)
+}

--- a/man/eval_con.Rd
+++ b/man/eval_con.Rd
@@ -2,10 +2,16 @@
 % Please edit documentation in R/connections.R
 \name{eval_con}
 \alias{eval_con}
-\title{A phylosql Function}
+\title{Evaluate a connection expression in the caller environment}
 \usage{
-eval_con(x)
+eval_con(expr)
+}
+\arguments{
+\item{expr}{Character string of R code that resolves to a connection when evaluated.}
+}
+\value{
+The evaluated object, typically a database connection.
 }
 \description{
-A phylosql Function
+Parses and evaluates a stored connection expression within the caller's environment.
 }

--- a/man/get_mtgn_connection.Rd
+++ b/man/get_mtgn_connection.Rd
@@ -2,10 +2,20 @@
 % Please edit documentation in R/connections.R
 \name{get_mtgn_connection}
 \alias{get_mtgn_connection}
-\title{A phylosql Function}
+\title{Establish and cache a connection to the MTGN database}
 \usage{
-get_mtgn_connection(path = NULL, key = NULL)
+get_mtgn_connection(path = NULL, key = NULL, refresh = FALSE)
+}
+\arguments{
+\item{path}{Path to a CSV containing connection credentials with columns \code{host}, \code{dbname}, \code{port}, and \code{user}.}
+
+\item{key}{Secret corresponding to the credentials in \code{path} (e.g. password).}
+
+\item{refresh}{Logical flag indicating whether to force reconnection even if a cached connection exists.}
+}
+\value{
+A live \code{DBIConnection} object.
 }
 \description{
-A phylosql Function
+Establishes a MariaDB connection using credentials from disk, caching the active connection and credentials for reuse across package calls.
 }

--- a/man/set_pool.Rd
+++ b/man/set_pool.Rd
@@ -2,10 +2,20 @@
 % Please edit documentation in R/connections.R
 \name{set_pool}
 \alias{set_pool}
-\title{A phylosql Function}
+\title{Establish a pooled connection to the MTGN database}
 \usage{
-set_pool(path, key)
+set_pool(path, key, size = NULL)
+}
+\arguments{
+\item{path}{Path to a CSV containing connection credentials with columns \code{host}, \code{dbname}, \code{port}, and \code{user}.}
+
+\item{key}{Secret corresponding to the credentials in \code{path} (e.g. password).}
+
+\item{size}{Optional list of pool sizing parameters forwarded to \code{pool::dbPool()}.}
+}
+\value{
+A \code{pool::Pool} instance representing the shared connection.
 }
 \description{
-A phylosql Function
+Creates or refreshes a connection pool for the MTGN database, closing any previously cached pool before establishing a new one.
 }

--- a/man/try_fetch_connection.Rd
+++ b/man/try_fetch_connection.Rd
@@ -2,10 +2,13 @@
 % Please edit documentation in R/connections.R
 \name{try_fetch_connection}
 \alias{try_fetch_connection}
-\title{A phylosql Function}
+\title{Attempt to reuse a cached connection or pool}
 \usage{
 try_fetch_connection()
 }
+\value{
+A live database connection object (either \code{DBIConnection} or \code{pool::Pool}) or \code{NULL} if none are cached.
+}
 \description{
-A phylosql Function
+Retrieves an existing cached database connection or pool when available, allowing callers to reuse previously established resources without reconnecting.
 }

--- a/man/try_fetch_connection_string.Rd
+++ b/man/try_fetch_connection_string.Rd
@@ -2,10 +2,13 @@
 % Please edit documentation in R/connections.R
 \name{try_fetch_connection_string}
 \alias{try_fetch_connection_string}
-\title{A phylosql Function}
+\title{Return the expression used to lazily fetch a connection}
 \usage{
 try_fetch_connection_string()
 }
+\value{
+A character string representing a call to \code{get_mtgn_connection()}.
+}
 \description{
-A phylosql Function
+Provides the textual expression needed to lazily obtain a connection, useful when storing deferred actions that should open a connection on demand.
 }

--- a/man/uploadData.Rd
+++ b/man/uploadData.Rd
@@ -2,17 +2,22 @@
 % Please edit documentation in R/upload.R
 \name{uploadData}
 \alias{uploadData}
-\title{A phylosql Function}
+\title{Bulk upload arbitrary data using \code{LOAD DATA}}
 \usage{
-uploadData(data, tableName, con = NULL)
+uploadData(data, tableName, con = NULL, use_transaction = FALSE)
 }
 \arguments{
-\item{data}{data to upload}
+\item{data}{A data frame of rows to upload.}
 
-\item{tableName}{database to send data}
+\item{tableName}{The fully qualified destination table name.}
 
-\item{con}{connection}
+\item{con}{An existing database connection. If \code{NULL}, a cached connection will be used.}
+
+\item{use_transaction}{Logical flag indicating whether to wrap the upload in a transaction.}
+}
+\value{
+Invisibly returns the rows uploaded.
 }
 \description{
-A backend function for bulk uploading data to a mysql database
+Writes the provided data to a temporary CSV file and executes MySQL's \code{LOAD DATA LOCAL INFILE} command to efficiently append the records, optionally within a transaction.
 }

--- a/man/upload_bulk_sv.Rd
+++ b/man/upload_bulk_sv.Rd
@@ -2,17 +2,20 @@
 % Please edit documentation in R/upload.R
 \name{upload_bulk_sv}
 \alias{upload_bulk_sv}
-\title{A phylosql Function}
+\title{Bulk upload sequence variant data using \code{LOAD DATA}}
 \usage{
 upload_bulk_sv(data, database = NULL, con = NULL)
 }
 \arguments{
-\item{data}{data to upload}
+\item{data}{A data frame containing sequence variant records.}
 
-\item{database}{database to send data}
+\item{database}{The name of the destination table.}
 
-\item{con}{connection}
+\item{con}{An existing database connection. If \code{NULL}, a cached connection will be used.}
+}
+\value{
+Invisibly returns the rows uploaded.
 }
 \description{
-function to upload a long format SV table to mysql database (quickly)
+Validates sequence variant data and uses MySQL's \code{LOAD DATA} command to append only the new rows to the destination table.
 }

--- a/man/upload_bulk_tax.Rd
+++ b/man/upload_bulk_tax.Rd
@@ -2,17 +2,20 @@
 % Please edit documentation in R/upload.R
 \name{upload_bulk_tax}
 \alias{upload_bulk_tax}
-\title{A phylosql Function}
+\title{Bulk upload taxonomy data using \code{LOAD DATA}}
 \usage{
 upload_bulk_tax(data, database = NULL, con = NULL)
 }
 \arguments{
-\item{data}{data to upload}
+\item{data}{A data frame containing taxonomy records.}
 
-\item{database}{database to send data}
+\item{database}{The name of the destination table.}
 
-\item{con}{connection}
+\item{con}{An existing database connection. If \code{NULL}, a cached connection will be used.}
+}
+\value{
+Invisibly returns the rows uploaded.
 }
 \description{
-function to upload a taxonomy table to mysql database (quickly)
+Cleans character data and uses MySQL's \code{LOAD DATA} command to append only new taxonomy rows to the destination table.
 }

--- a/man/upload_cms_data.Rd
+++ b/man/upload_cms_data.Rd
@@ -2,17 +2,20 @@
 % Please edit documentation in R/upload.R
 \name{upload_cms_data}
 \alias{upload_cms_data}
-\title{A phylosql Function}
+\title{Upload CMS data to a MySQL database}
 \usage{
 upload_cms_data(data, database = "cmsdata", con = NULL)
 }
 \arguments{
-\item{data}{data to upload}
+\item{data}{A data frame containing CMS records.}
 
-\item{database}{database to send data}
+\item{database}{The name of the destination table.}
 
-\item{con}{connection}
+\item{con}{An existing database connection. If \code{NULL}, a cached connection will be used.}
+}
+\value{
+Invisibly returns the rows uploaded.
 }
 \description{
-function to upload cms data to mysql database
+Appends new CMS rows to the destination table, skipping entries that already exist.
 }

--- a/man/upload_cms_data_Long.Rd
+++ b/man/upload_cms_data_Long.Rd
@@ -2,17 +2,20 @@
 % Please edit documentation in R/upload.R
 \name{upload_cms_data_Long}
 \alias{upload_cms_data_Long}
-\title{A phylosql Function}
+\title{Upload CMS long-format data to a MySQL database}
 \usage{
 upload_cms_data_Long(data, database = "cmsdatalong", con = NULL)
 }
 \arguments{
-\item{data}{data to upload}
+\item{data}{A data frame containing long-format CMS records with columns \code{MetagenNumber}, \code{Factor}, and \code{Level}.}
 
-\item{database}{database to send data}
+\item{database}{The name of the destination table.}
 
-\item{con}{connection}
+\item{con}{An existing database connection. If \code{NULL}, a cached connection will be used.}
+}
+\value{
+Invisibly returns the rows uploaded.
 }
 \description{
-function to upload cms data to mysql database
+Validates CMS long-format records (ensuring no missing \code{Level} values) and appends new rows while skipping duplicates.
 }

--- a/man/upload_lab_data.Rd
+++ b/man/upload_lab_data.Rd
@@ -2,17 +2,20 @@
 % Please edit documentation in R/upload.R
 \name{upload_lab_data}
 \alias{upload_lab_data}
-\title{A phylosql Function}
+\title{Upload laboratory data to a MySQL database}
 \usage{
 upload_lab_data(data, database = "labdata", con = NULL)
 }
 \arguments{
-\item{data}{data to upload}
+\item{data}{A data frame containing laboratory records.}
 
-\item{database}{database to send data}
+\item{database}{The name of the destination table.}
 
-\item{con}{connection}
+\item{con}{An existing database connection. If \code{NULL}, a cached connection will be used.}
+}
+\value{
+Invisibly returns the rows uploaded.
 }
 \description{
-function to upload lab data to mysql database
+Validates laboratory records and appends new rows to the specified laboratory table, skipping rows that already exist.
 }

--- a/man/upload_sv.Rd
+++ b/man/upload_sv.Rd
@@ -2,17 +2,20 @@
 % Please edit documentation in R/upload.R
 \name{upload_sv}
 \alias{upload_sv}
-\title{A phylosql Function}
+\title{Upload sequence variant data to a MySQL database}
 \usage{
 upload_sv(data, database = NULL, con = NULL)
 }
 \arguments{
-\item{data}{data to upload}
+\item{data}{A data frame containing sequence variant records.}
 
-\item{database}{database to send data}
+\item{database}{The name of the destination table.}
 
-\item{con}{connection}
+\item{con}{An existing database connection. If \code{NULL}, a cached connection will be used.}
+}
+\value{
+Invisibly returns the rows uploaded.
 }
 \description{
-function to upload sv table to mysql database
+Validates sequence variant records and appends new rows, skipping entries that already exist in the destination table.
 }

--- a/man/upload_taxonomy.Rd
+++ b/man/upload_taxonomy.Rd
@@ -2,17 +2,20 @@
 % Please edit documentation in R/upload.R
 \name{upload_taxonomy}
 \alias{upload_taxonomy}
-\title{A phylosql Function}
+\title{Upload taxonomy data to a MySQL database}
 \usage{
 upload_taxonomy(data, database = NULL, con = NULL)
 }
 \arguments{
-\item{data}{data to upload}
+\item{data}{A data frame containing taxonomy records.}
 
-\item{database}{database to send data}
+\item{database}{The name of the destination table.}
 
-\item{con}{connection}
+\item{con}{An existing database connection. If \code{NULL}, a cached connection will be used.}
+}
+\value{
+Invisibly returns the rows uploaded.
 }
 \description{
-function to upload taxonomy table to mysql database
+Cleans character data of carriage returns, validates inputs, and appends new taxonomy rows while skipping existing entries.
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(phylosql)
+
+test_check("phylosql")

--- a/tests/testthat/helper-reset.R
+++ b/tests/testthat/helper-reset.R
@@ -1,0 +1,4 @@
+reset_phylosql_state <- function() {
+  env <- phylosql:::.phylosql_state
+  rm(list = ls(env), envir = env)
+}

--- a/tests/testthat/test-connections.R
+++ b/tests/testthat/test-connections.R
@@ -1,0 +1,61 @@
+test_that("credentials must exist and are cached", {
+  reset_phylosql_state()
+
+  creds <- data.frame(
+    host = "localhost",
+    dbname = "microbiome",
+    port = 3306,
+    user = "tester",
+    stringsAsFactors = FALSE
+  )
+
+  cred_path <- tempfile(fileext = ".csv")
+  on.exit(unlink(cred_path), add = TRUE)
+  utils::write.csv(creds, cred_path, row.names = FALSE)
+
+  fake_connection <- structure(list(id = 1L), class = "FakeConnection")
+
+  with_mocked_bindings({
+    con1 <- get_mtgn_connection(path = cred_path, key = "secret")
+    expect_identical(con1, fake_connection)
+    expect_identical(phylosql:::.phylosql_state$key, "secret")
+
+    con2 <- get_mtgn_connection()
+    expect_identical(con2, fake_connection)
+  },
+  DBI::dbConnect = function(...) fake_connection,
+  DBI::dbDisconnect = function(...) NULL,
+  DBI::dbIsValid = function(con) TRUE)
+})
+
+
+test_that("refresh forces reconnection", {
+  reset_phylosql_state()
+
+  creds <- data.frame(
+    host = "localhost",
+    dbname = "microbiome",
+    port = 3306,
+    user = "tester",
+    stringsAsFactors = FALSE
+  )
+
+  cred_path <- tempfile(fileext = ".csv")
+  on.exit(unlink(cred_path), add = TRUE)
+  utils::write.csv(creds, cred_path, row.names = FALSE)
+
+  calls <- 0
+  fake_connection <- structure(list(id = 1L), class = "FakeConnection")
+
+  with_mocked_bindings({
+    get_mtgn_connection(path = cred_path, key = "secret")
+    get_mtgn_connection(refresh = TRUE)
+    expect_equal(calls, 2)
+  },
+  DBI::dbConnect = function(...) {
+    calls <<- calls + 1
+    fake_connection
+  },
+  DBI::dbDisconnect = function(...) NULL,
+  DBI::dbIsValid = function(con) calls > 0)
+})

--- a/tests/testthat/test-upload.R
+++ b/tests/testthat/test-upload.R
@@ -1,0 +1,51 @@
+test_that("upload functions validate required columns", {
+  dummy_con <- structure(list(), class = "Dummy")
+
+  with_mocked_bindings({
+    expect_error(upload_lab_data(NULL, con = dummy_con), "must not be NULL")
+    expect_error(upload_lab_data(data.frame(foo = 1), con = dummy_con), "Missing required column")
+  },
+  resolve_connection = function(con = NULL) dummy_con)
+})
+
+
+test_that("upload_lab_data skips existing rows", {
+  dummy_con <- structure(list(), class = "Dummy")
+  data <- data.frame(
+    MetagenNumber = 1,
+    variable = "depth",
+    value = 42
+  )
+
+  with_mocked_bindings({
+    expect_message(upload_lab_data(data, con = dummy_con), "No new records to upload.")
+  },
+  resolve_connection = function(con = NULL) dummy_con,
+  collect_existing_keys = function(...) data[c("MetagenNumber", "variable")],
+  compute_new_indices = function(existing, candidate, key_cols) integer())
+})
+
+
+test_that("uploadData executes bulk loader", {
+  dummy_con <- structure(list(), class = "Dummy")
+  executed <- FALSE
+  temp_path <- file.path(tempdir(), "phylosql-test-upload.csv")
+  if (file.exists(temp_path)) {
+    file.remove(temp_path)
+  }
+
+  with_mocked_bindings({
+    uploadData(data.frame(x = 1), "schema.table", con = dummy_con)
+    expect_true(executed)
+    expect_false(file.exists(temp_path))
+  },
+  resolve_connection = function(con = NULL) dummy_con,
+  tempfile = function(...) temp_path,
+  DBI::dbQuoteString = function(con, x) DBI::SQL(sprintf("'%s'", x)),
+  DBI::dbQuoteIdentifier = function(con, x) DBI::SQL(x),
+  DBI::dbExecute = function(con, query) {
+    executed <<- TRUE
+    invisible(0)
+  },
+  DBI::dbWithTransaction = function(con, code) code)
+})


### PR DESCRIPTION
## Summary
- replace the global sql_creds usage with an internal package state and helper utilities for credential loading and connection caching
- tighten upload helpers with input validation, duplicate skipping, reusable shared logic, and safer bulk loading behavior
- document the new behaviour and add testthat scaffolding for connection caching and upload validation

## Testing
- not run (Rscript is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_b_68e4800215308321847782e922d57337