### PR TITLE
Use imported .data pronoun

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -124,7 +124,7 @@ fetch_taxonomy <- function(con = NULL, database = "eukaryota_tax", whichTaxa = N
 
   if (!is.null(whichTaxa)) {
     whichTaxa <- unique(as.character(whichTaxa))
-    tax_tbl <- dplyr::filter(tax_tbl, rlang::.data$SV %in% !!whichTaxa)
+    tax_tbl <- dplyr::filter(tax_tbl, .data$SV %in% !!whichTaxa)
   }
 
   tax <- dplyr::collect(tax_tbl)
@@ -243,8 +243,8 @@ get_svs <- function(database = NULL, con = NULL) {
   con_obj <- resolve_connection(con)
 
   dplyr::tbl(con_obj, database) %>%
-    dplyr::distinct(rlang::.data$SV) %>%
-    dplyr::arrange(rlang::.data$SV) %>%
+    dplyr::distinct(.data$SV) %>%
+    dplyr::arrange(.data$SV) %>%
     dplyr::pull("SV")
 }
 
@@ -302,7 +302,7 @@ build_asv_sparse <- function(con, database, samples = NULL) {
 
   if (!is.null(samples)) {
     samples <- unique(as.character(samples))
-    asv_tbl <- dplyr::filter(asv_tbl, rlang::.data$MetagenNumber %in% !!samples)
+    asv_tbl <- dplyr::filter(asv_tbl, .data$MetagenNumber %in% !!samples)
   }
 
   asv_long <- dplyr::collect(asv_tbl)

--- a/R/tidy_sample_data.R
+++ b/R/tidy_sample_data.R
@@ -18,7 +18,7 @@ ms_as_cmsData <- function(data) {
   tibble::as_tibble(cms) %>%
     dplyr::mutate(
       SurveyID = NA_character_,
-      TargetCropTypeName = dplyr::coalesce(rlang::.data$TargetCropTypeName, NA_character_)
+      TargetCropTypeName = dplyr::coalesce(.data$TargetCropTypeName, NA_character_)
     ) %>%
     dplyr::select(
       "MetagenNumber", "PropertyName", "SurveyID", "BlockName",
@@ -47,7 +47,7 @@ cms_as_cmsData <- function(data) {
       SurveyID = "SurveyId",
       MetagenNumber = "BarcodeId"
     ) %>%
-    dplyr::mutate(SurveyID = as.character(rlang::.data$SurveyID)) %>%
+    dplyr::mutate(SurveyID = as.character(.data$SurveyID)) %>%
     dplyr::select(
       "MetagenNumber", "PropertyName", "SurveyID", "BlockName",
       "CropName", "SurveyDate", "Location", "AgronomistName",
@@ -75,12 +75,12 @@ as_labData <- function(labdata) {
 
   cleaned <- renamed %>%
     dplyr::mutate(
-      SoilMoisture = suppressWarnings(as.numeric(rlang::.data$SoilMoisture)),
+      SoilMoisture = suppressWarnings(as.numeric(.data$SoilMoisture)),
       dplyr::across(
         c("ActiveCarbon", "pH", "Phosphatase", "B_Glucosidase", "DNAConc", "SoilMoisture"),
         ~ replace(.x, .x == 0, NA_real_)
       ),
-      SoilMoisture = replace(rlang::.data$SoilMoisture, rlang::.data$SoilMoisture < 0, NA_real_)
+      SoilMoisture = replace(.data$SoilMoisture, .data$SoilMoisture < 0, NA_real_)
     )
 
   cleaned %>%


### PR DESCRIPTION
## Summary
- use the imported `.data` pronoun in dplyr filters so rlang does not need to be referenced via the namespace operator
- update metadata tidying helpers to rely on the same approach for their mutate calls

## Testing
- R -q -e "testthat::test_dir('tests/testthat', reporter = 'summary')" *(fails: `R` executable is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ac598d23c8321b1fe38f87856f346)